### PR TITLE
[CodeTest] 로그인, 와인 구매 기능 구현

### DIFF
--- a/lib/app/auth/bindings/auth_binding.dart
+++ b/lib/app/auth/bindings/auth_binding.dart
@@ -1,0 +1,16 @@
+import 'package:epicone_review/app/auth/provider/repositories/auth_repository.dart';
+import 'package:get/get.dart';
+
+import '../controllers/auth_controller.dart';
+
+class AuthBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<AuthRepository>(() => AuthRepositoryImpl());
+    Get.lazyPut<AuthController>(
+      () => AuthController(
+        Get.find<AuthRepository>(),
+      ),
+    );
+  }
+}

--- a/lib/app/auth/bindings/auth_binding.dart
+++ b/lib/app/auth/bindings/auth_binding.dart
@@ -1,3 +1,4 @@
+import 'package:epicone_review/app/auth/provider/api/auth_api.dart';
 import 'package:epicone_review/app/auth/provider/repositories/auth_repository.dart';
 import 'package:get/get.dart';
 
@@ -6,7 +7,12 @@ import '../controllers/auth_controller.dart';
 class AuthBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut<AuthRepository>(() => AuthRepositoryImpl());
+    Get.lazyPut<AuthApi>(() => AuthApi());
+    Get.lazyPut<AuthRepository>(
+      () => AuthRepositoryImpl(
+        authApi: Get.find<AuthApi>(),
+      ),
+    );
     Get.lazyPut<AuthController>(
       () => AuthController(
         Get.find<AuthRepository>(),

--- a/lib/app/auth/controllers/auth_controller.dart
+++ b/lib/app/auth/controllers/auth_controller.dart
@@ -1,0 +1,50 @@
+import 'package:epicone_review/app/auth/provider/models/login/login.dart';
+import 'package:epicone_review/app/auth/provider/repositories/auth_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class AuthController extends GetxController {
+  static AuthController get to => Get.find();
+
+  final AuthRepository _authRepository;
+  var isLoading = false.obs;
+  var user = Rxn<Login>(null);
+
+  AuthController(this._authRepository);
+
+  // 로그인, 실패 시 5번 재요청 후 오류 다이얼로그
+  void login() async {
+    try {
+      isLoading(true);
+      var res = await _authRepository.login(retryCnt: 5);
+      user.value = res;
+    } catch (e) {
+      _errorDialog('로그인에 실패했습니다.\n오류가 반복될 경우 고객센터 문의 부탁드립니다.');
+    } finally {
+      isLoading(false);
+    }
+  }
+
+  void logout() {
+    user.value = null;
+  }
+
+  void _errorDialog(String message) {
+    Get.dialog(
+      AlertDialog(
+        title: Text(
+          '오류 발생',
+        ),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Get.back();
+            },
+            child: Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/auth/controllers/auth_controller.dart
+++ b/lib/app/auth/controllers/auth_controller.dart
@@ -7,21 +7,25 @@ class AuthController extends GetxController {
   static AuthController get to => Get.find();
 
   final AuthRepository _authRepository;
-  var isLoading = false.obs;
+  AuthController(this._authRepository);
+
+  var isLoadingLogin = false.obs;
   var user = Rxn<Login>(null);
 
-  AuthController(this._authRepository);
+  Map<String, String> getTokenHeader() {
+    return {'Authorization': 'Basic ${user.value?.id}'};
+  }
 
   // 로그인, 실패 시 5번 재요청 후 오류 다이얼로그
   void login() async {
     try {
-      isLoading(true);
+      isLoadingLogin(true);
       var res = await _authRepository.login(retryCnt: 5);
       user.value = res;
     } catch (e) {
       _errorDialog('로그인에 실패했습니다.\n오류가 반복될 경우 고객센터 문의 부탁드립니다.');
     } finally {
-      isLoading(false);
+      isLoadingLogin(false);
     }
   }
 

--- a/lib/app/auth/provider/api/auth_api.dart
+++ b/lib/app/auth/provider/api/auth_api.dart
@@ -1,0 +1,8 @@
+import 'package:get/get.dart';
+
+class AuthApi extends GetConnect {
+  Future<Response> login() async {
+    const url = 'https://dev-api.epicone.co.kr/api/v1/review/user';
+    return await get(url);
+  }
+}

--- a/lib/app/auth/provider/models/login/feature.dart
+++ b/lib/app/auth/provider/models/login/feature.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'feature.freezed.dart';
+part 'feature.g.dart';
+
+@freezed
+class Feature with _$Feature {
+  factory Feature({
+    String? key,
+    String? name,
+    @JsonKey(name: 'point_can_use_limit') double? pointCanUseLimit,
+  }) = _Feature;
+
+  factory Feature.fromJson(Map<String, dynamic> json) =>
+      _$FeatureFromJson(json);
+}

--- a/lib/app/auth/provider/models/login/feature.freezed.dart
+++ b/lib/app/auth/provider/models/login/feature.freezed.dart
@@ -1,0 +1,195 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'feature.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Feature _$FeatureFromJson(Map<String, dynamic> json) {
+  return _Feature.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Feature {
+  String? get key => throw _privateConstructorUsedError;
+  String? get name => throw _privateConstructorUsedError;
+  @JsonKey(name: 'point_can_use_limit')
+  double? get pointCanUseLimit => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $FeatureCopyWith<Feature> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $FeatureCopyWith<$Res> {
+  factory $FeatureCopyWith(Feature value, $Res Function(Feature) then) =
+      _$FeatureCopyWithImpl<$Res, Feature>;
+  @useResult
+  $Res call(
+      {String? key,
+      String? name,
+      @JsonKey(name: 'point_can_use_limit') double? pointCanUseLimit});
+}
+
+/// @nodoc
+class _$FeatureCopyWithImpl<$Res, $Val extends Feature>
+    implements $FeatureCopyWith<$Res> {
+  _$FeatureCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = freezed,
+    Object? name = freezed,
+    Object? pointCanUseLimit = freezed,
+  }) {
+    return _then(_value.copyWith(
+      key: freezed == key
+          ? _value.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pointCanUseLimit: freezed == pointCanUseLimit
+          ? _value.pointCanUseLimit
+          : pointCanUseLimit // ignore: cast_nullable_to_non_nullable
+              as double?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_FeatureCopyWith<$Res> implements $FeatureCopyWith<$Res> {
+  factory _$$_FeatureCopyWith(
+          _$_Feature value, $Res Function(_$_Feature) then) =
+      __$$_FeatureCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? key,
+      String? name,
+      @JsonKey(name: 'point_can_use_limit') double? pointCanUseLimit});
+}
+
+/// @nodoc
+class __$$_FeatureCopyWithImpl<$Res>
+    extends _$FeatureCopyWithImpl<$Res, _$_Feature>
+    implements _$$_FeatureCopyWith<$Res> {
+  __$$_FeatureCopyWithImpl(_$_Feature _value, $Res Function(_$_Feature) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = freezed,
+    Object? name = freezed,
+    Object? pointCanUseLimit = freezed,
+  }) {
+    return _then(_$_Feature(
+      key: freezed == key
+          ? _value.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pointCanUseLimit: freezed == pointCanUseLimit
+          ? _value.pointCanUseLimit
+          : pointCanUseLimit // ignore: cast_nullable_to_non_nullable
+              as double?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Feature implements _Feature {
+  _$_Feature(
+      {this.key,
+      this.name,
+      @JsonKey(name: 'point_can_use_limit') this.pointCanUseLimit});
+
+  factory _$_Feature.fromJson(Map<String, dynamic> json) =>
+      _$$_FeatureFromJson(json);
+
+  @override
+  final String? key;
+  @override
+  final String? name;
+  @override
+  @JsonKey(name: 'point_can_use_limit')
+  final double? pointCanUseLimit;
+
+  @override
+  String toString() {
+    return 'Feature(key: $key, name: $name, pointCanUseLimit: $pointCanUseLimit)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Feature &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.pointCanUseLimit, pointCanUseLimit) ||
+                other.pointCanUseLimit == pointCanUseLimit));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, name, pointCanUseLimit);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_FeatureCopyWith<_$_Feature> get copyWith =>
+      __$$_FeatureCopyWithImpl<_$_Feature>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_FeatureToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Feature implements Feature {
+  factory _Feature(
+      {final String? key,
+      final String? name,
+      @JsonKey(name: 'point_can_use_limit')
+          final double? pointCanUseLimit}) = _$_Feature;
+
+  factory _Feature.fromJson(Map<String, dynamic> json) = _$_Feature.fromJson;
+
+  @override
+  String? get key;
+  @override
+  String? get name;
+  @override
+  @JsonKey(name: 'point_can_use_limit')
+  double? get pointCanUseLimit;
+  @override
+  @JsonKey(ignore: true)
+  _$$_FeatureCopyWith<_$_Feature> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/app/auth/provider/models/login/feature.g.dart
+++ b/lib/app/auth/provider/models/login/feature.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'feature.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Feature _$$_FeatureFromJson(Map<String, dynamic> json) => _$_Feature(
+      key: json['key'] as String?,
+      name: json['name'] as String?,
+      pointCanUseLimit: (json['point_can_use_limit'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$$_FeatureToJson(_$_Feature instance) =>
+    <String, dynamic>{
+      'key': instance.key,
+      'name': instance.name,
+      'point_can_use_limit': instance.pointCanUseLimit,
+    };

--- a/lib/app/auth/provider/models/login/login.dart
+++ b/lib/app/auth/provider/models/login/login.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'feature.dart';
+
+part 'login.freezed.dart';
+part 'login.g.dart';
+
+@freezed
+class Login with _$Login {
+  factory Login({
+    String? id,
+    String? name,
+    @JsonKey(name: 'point_remained') int? pointRemained,
+    List<Feature>? features,
+  }) = _Login;
+
+  factory Login.fromJson(Map<String, dynamic> json) => _$LoginFromJson(json);
+}

--- a/lib/app/auth/provider/models/login/login.freezed.dart
+++ b/lib/app/auth/provider/models/login/login.freezed.dart
@@ -1,0 +1,221 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'login.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Login _$LoginFromJson(Map<String, dynamic> json) {
+  return _Login.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Login {
+  String? get id => throw _privateConstructorUsedError;
+  String? get name => throw _privateConstructorUsedError;
+  @JsonKey(name: 'point_remained')
+  int? get pointRemained => throw _privateConstructorUsedError;
+  List<Feature>? get features => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $LoginCopyWith<Login> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LoginCopyWith<$Res> {
+  factory $LoginCopyWith(Login value, $Res Function(Login) then) =
+      _$LoginCopyWithImpl<$Res, Login>;
+  @useResult
+  $Res call(
+      {String? id,
+      String? name,
+      @JsonKey(name: 'point_remained') int? pointRemained,
+      List<Feature>? features});
+}
+
+/// @nodoc
+class _$LoginCopyWithImpl<$Res, $Val extends Login>
+    implements $LoginCopyWith<$Res> {
+  _$LoginCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? name = freezed,
+    Object? pointRemained = freezed,
+    Object? features = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pointRemained: freezed == pointRemained
+          ? _value.pointRemained
+          : pointRemained // ignore: cast_nullable_to_non_nullable
+              as int?,
+      features: freezed == features
+          ? _value.features
+          : features // ignore: cast_nullable_to_non_nullable
+              as List<Feature>?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_LoginCopyWith<$Res> implements $LoginCopyWith<$Res> {
+  factory _$$_LoginCopyWith(_$_Login value, $Res Function(_$_Login) then) =
+      __$$_LoginCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? id,
+      String? name,
+      @JsonKey(name: 'point_remained') int? pointRemained,
+      List<Feature>? features});
+}
+
+/// @nodoc
+class __$$_LoginCopyWithImpl<$Res> extends _$LoginCopyWithImpl<$Res, _$_Login>
+    implements _$$_LoginCopyWith<$Res> {
+  __$$_LoginCopyWithImpl(_$_Login _value, $Res Function(_$_Login) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? name = freezed,
+    Object? pointRemained = freezed,
+    Object? features = freezed,
+  }) {
+    return _then(_$_Login(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pointRemained: freezed == pointRemained
+          ? _value.pointRemained
+          : pointRemained // ignore: cast_nullable_to_non_nullable
+              as int?,
+      features: freezed == features
+          ? _value._features
+          : features // ignore: cast_nullable_to_non_nullable
+              as List<Feature>?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Login implements _Login {
+  _$_Login(
+      {this.id,
+      this.name,
+      @JsonKey(name: 'point_remained') this.pointRemained,
+      final List<Feature>? features})
+      : _features = features;
+
+  factory _$_Login.fromJson(Map<String, dynamic> json) =>
+      _$$_LoginFromJson(json);
+
+  @override
+  final String? id;
+  @override
+  final String? name;
+  @override
+  @JsonKey(name: 'point_remained')
+  final int? pointRemained;
+  final List<Feature>? _features;
+  @override
+  List<Feature>? get features {
+    final value = _features;
+    if (value == null) return null;
+    if (_features is EqualUnmodifiableListView) return _features;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString() {
+    return 'Login(id: $id, name: $name, pointRemained: $pointRemained, features: $features)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Login &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.pointRemained, pointRemained) ||
+                other.pointRemained == pointRemained) &&
+            const DeepCollectionEquality().equals(other._features, _features));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, pointRemained,
+      const DeepCollectionEquality().hash(_features));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_LoginCopyWith<_$_Login> get copyWith =>
+      __$$_LoginCopyWithImpl<_$_Login>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_LoginToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Login implements Login {
+  factory _Login(
+      {final String? id,
+      final String? name,
+      @JsonKey(name: 'point_remained') final int? pointRemained,
+      final List<Feature>? features}) = _$_Login;
+
+  factory _Login.fromJson(Map<String, dynamic> json) = _$_Login.fromJson;
+
+  @override
+  String? get id;
+  @override
+  String? get name;
+  @override
+  @JsonKey(name: 'point_remained')
+  int? get pointRemained;
+  @override
+  List<Feature>? get features;
+  @override
+  @JsonKey(ignore: true)
+  _$$_LoginCopyWith<_$_Login> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/app/auth/provider/models/login/login.g.dart
+++ b/lib/app/auth/provider/models/login/login.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'login.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Login _$$_LoginFromJson(Map<String, dynamic> json) => _$_Login(
+      id: json['id'] as String?,
+      name: json['name'] as String?,
+      pointRemained: json['point_remained'] as int?,
+      features: (json['features'] as List<dynamic>?)
+          ?.map((e) => Feature.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$_LoginToJson(_$_Login instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'point_remained': instance.pointRemained,
+      'features': instance.features,
+    };

--- a/lib/app/auth/provider/repositories/auth_repository.dart
+++ b/lib/app/auth/provider/repositories/auth_repository.dart
@@ -1,0 +1,30 @@
+import 'package:epicone_review/app/auth/provider/models/login/login.dart';
+import 'package:epicone_review/app/auth/provider/api/auth_api.dart';
+import 'package:get/get.dart';
+
+abstract class AuthRepository {
+  Future<Login> login({int retryCnt = 3});
+}
+
+class AuthRepositoryImpl implements AuthRepository {
+  AuthRepositoryImpl();
+
+  final authApi = AuthApi();
+
+  // 로그인 메소드, 오류 발생시 3회까지 재시도 디폴트
+  @override
+  Future<Login> login({int retryCnt = 3}) async {
+    for (var tryCtn = 0; tryCtn < retryCnt; tryCtn++) {
+      try {
+        Response res = await authApi.login();
+        if (res.statusCode == 200) {
+          return Login.fromJson(res.body);
+        }
+        throw Exception('login error: status code ${res.statusCode}');
+      } catch (e) {
+        await Future.delayed(Duration(seconds: 3));
+      }
+    }
+    throw Exception('login failed');
+  }
+}

--- a/lib/app/auth/provider/repositories/auth_repository.dart
+++ b/lib/app/auth/provider/repositories/auth_repository.dart
@@ -7,9 +7,9 @@ abstract class AuthRepository {
 }
 
 class AuthRepositoryImpl implements AuthRepository {
-  AuthRepositoryImpl();
+  final AuthApi authApi;
 
-  final authApi = AuthApi();
+  AuthRepositoryImpl({required this.authApi});
 
   // 로그인 메소드, 오류 발생시 3회까지 재시도 디폴트
   @override

--- a/lib/app/wine/bindings/wine_purchase_binding.dart
+++ b/lib/app/wine/bindings/wine_purchase_binding.dart
@@ -1,0 +1,18 @@
+import 'package:epicone_review/app/wine/controllers/wine_purchase_controller.dart';
+import 'package:epicone_review/app/wine/models/wine.dart';
+import 'package:get/get.dart';
+
+import '../repositories/wine_repository.dart';
+
+class WinePurchaseBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<WineRepository>(() => WineRepositoryImpl());
+    Get.lazyPut<WinePurchaseController>(
+      () => WinePurchaseController(
+        Get.arguments as Wine,
+        Get.find<WineRepository>(),
+      ),
+    );
+  }
+}

--- a/lib/app/wine/controllers/wine_purchase_controller.dart
+++ b/lib/app/wine/controllers/wine_purchase_controller.dart
@@ -1,0 +1,164 @@
+import 'package:epicone_review/app/auth/controllers/auth_controller.dart';
+import 'package:epicone_review/app/auth/provider/models/login/feature.dart';
+import 'package:epicone_review/app/wine/models/wine.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../repositories/wine_repository.dart';
+
+class WinePurchaseController extends GetxController {
+  static WinePurchaseController get to => Get.find();
+
+  final Wine wine;
+  final WineRepository _wineRepository;
+  WinePurchaseController(this.wine, this._wineRepository);
+
+  final AuthController _authController = AuthController.to;
+
+  var isLoadingPurchase = false.obs;
+
+  late FocusNode addressFocusNode;
+  late FocusNode addressDetailFocusNode;
+  late FocusNode pointsUsedFocusNode;
+
+  late int pointCanUseLimit;
+
+  final addressController = TextEditingController();
+  final addressDetailController = TextEditingController();
+  final pointsUsedController = TextEditingController();
+
+  var confirmPointsUsed = ''.obs;
+  var confirmPrice = ''.obs;
+
+  Map<String, String> getPurchaseInfo() => {
+        'address': addressController.text,
+        'address_detail': addressDetailController.text,
+        'points_used': confirmPointsUsed.value,
+        'price': confirmPrice.value,
+        'order_name': wine.wine,
+      };
+
+  @override
+  void onInit() {
+    super.onInit();
+    init();
+
+    addressFocusNode = FocusNode();
+    addressDetailFocusNode = FocusNode();
+    pointsUsedFocusNode = FocusNode();
+  }
+
+  @override
+  void onClose() {
+    addressController.dispose();
+    addressDetailController.dispose();
+    pointsUsedController.dispose();
+
+    addressFocusNode.dispose();
+    addressDetailFocusNode.dispose();
+    pointsUsedFocusNode.dispose();
+    super.onClose();
+  }
+
+  void init() {
+    confirmPointsUsed.value = '0';
+    confirmPrice.value = wine.price.toString();
+    setPointCanUseLimit();
+  }
+
+  // 최대 사용가능 포인트 계산
+  void setPointCanUseLimit() {
+    double? pointCanUseLimitPercent = _authController.user.value?.features!
+        .firstWhere(
+          (feature) => feature.key == 'order',
+          orElse: () =>
+              Feature(key: 'order', name: '구매하기', pointCanUseLimit: 1),
+        )
+        .pointCanUseLimit;
+
+    pointCanUseLimit = (wine.price * pointCanUseLimitPercent!).toInt();
+  }
+
+  // 포인트 사용하기 버튼 클릭시 동작
+  void clickUsePointBtn() {
+    if (int.parse(pointsUsedController.text) <= 0) {
+      return;
+    }
+
+    if ((int.parse(pointsUsedController.text) > pointCanUseLimit) ||
+        (int.parse(pointsUsedController.text) >
+            (_authController.user.value?.pointRemained ?? 0))) {
+      Get.dialog(
+        AlertDialog(
+          content: Text('보유 포인트와 사용가능 포인트를 확인해주세요.'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Get.back();
+              },
+              child: Text('확인'),
+            ),
+          ],
+        ),
+      );
+    } else {
+      confirmPointsUsed.value = pointsUsedController.text;
+      confirmPrice.value =
+          (wine.price - int.parse(pointsUsedController.text)).toString();
+      showDialog('${confirmPointsUsed.value} 포인트가 적용되었습니다.');
+    }
+  }
+
+  // 구매하기 api 요청
+  void postPurchase() async {
+    if (addressController.text.trim().isEmpty ||
+        addressDetailController.text.trim().isEmpty) {
+      showDialog('주소를 입력해주세요.');
+      return;
+    }
+
+    var header = _authController.getTokenHeader();
+    var body = getPurchaseInfo();
+
+    try {
+      isLoadingPurchase(true);
+      var res = await _wineRepository.purchase(
+        header: header,
+        body: body,
+        retryCnt: 5,
+      );
+
+      switch (res) {
+        case 200:
+          Get.back();
+          showDialog('주문 성공');
+          break;
+        case 418:
+          showDialog('잔액이 부족합니다.');
+          break;
+        default:
+          showDialog('주문 실패');
+      }
+    } catch (e) {
+      showDialog('주문 실패');
+    } finally {
+      isLoadingPurchase(false);
+    }
+  }
+
+  void showDialog(String message) {
+    Get.dialog(
+      AlertDialog(
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Get.back();
+            },
+            child: Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/wine/pages/wine_detail_page.dart
+++ b/lib/app/wine/pages/wine_detail_page.dart
@@ -1,4 +1,8 @@
+import 'package:epicone_review/app/auth/controllers/auth_controller.dart';
+import 'package:epicone_review/app/wine/pages/wine_purchase_page.dart';
+import 'package:epicone_review/router/app_pages.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 import '../models/wine.dart';
 
@@ -14,6 +18,8 @@ class WineDetailPage extends StatefulWidget {
 }
 
 class _WineDetailPageState extends State<WineDetailPage> {
+  final AuthController _authController = AuthController.to;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -33,6 +39,44 @@ class _WineDetailPageState extends State<WineDetailPage> {
               widget.wine.winery,
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.displayLarge,
+            ),
+            SizedBox(height: 20),
+            InkWell(
+              onTap: () {
+                if (_authController.user.value == null) {
+                  Get.dialog(
+                    AlertDialog(
+                      content: Text('로그인이 필요합니다.'),
+                      actions: [
+                        TextButton(
+                          onPressed: () {
+                            Get.back();
+                          },
+                          child: Text('확인'),
+                        ),
+                      ],
+                    ),
+                  );
+                  return;
+                }
+
+                Get.toNamed(
+                  Routes.WINE_PURCHASE,
+                  arguments: widget.wine,
+                );
+              },
+              child: Container(
+                padding: EdgeInsets.all(12.0),
+                decoration: BoxDecoration(
+                  border: Border.all(width: 1.0),
+                  borderRadius: BorderRadius.circular(13.0),
+                ),
+                child: Text(
+                  'Purchase',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ),
             ),
           ],
         ),

--- a/lib/app/wine/pages/wine_detail_page.dart
+++ b/lib/app/wine/pages/wine_detail_page.dart
@@ -22,18 +22,20 @@ class _WineDetailPageState extends State<WineDetailPage> {
           widget.wine.wine,
         ),
       ),
-      body: Column(
-        children: [
-          Center(
-            child: Image.network(widget.wine.image),
-          ),
-          SizedBox(height: 20),
-          Text(
-            widget.wine.winery,
-            textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.displayLarge,
-          ),
-        ],
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Center(
+              child: Image.network(widget.wine.image),
+            ),
+            SizedBox(height: 20),
+            Text(
+              widget.wine.winery,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.displayLarge,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/wine/pages/wine_page.dart
+++ b/lib/app/wine/pages/wine_page.dart
@@ -42,7 +42,7 @@ class _WinePageState extends State<WinePage> {
               expandedHeight: 110,
               actions: [
                 _authController.user.value == null
-                    ? _authController.isLoading.value
+                    ? _authController.isLoadingLogin.value
                         ? Center(child: CircularProgressIndicator())
                         : InkWell(
                             onTap: () {

--- a/lib/app/wine/pages/wine_page.dart
+++ b/lib/app/wine/pages/wine_page.dart
@@ -1,3 +1,4 @@
+import 'package:epicone_review/app/auth/controllers/auth_controller.dart';
 import 'package:epicone_review/app/wine/pages/wine_detail_page.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -17,6 +18,7 @@ class WinePage extends StatefulWidget {
 class _WinePageState extends State<WinePage> {
   final RootController _rootController = RootController.to;
   final WineController _wineController = WineController.to;
+  final AuthController _authController = AuthController.to;
 
   List<Wine> _wines = [];
 
@@ -39,6 +41,44 @@ class _WinePageState extends State<WinePage> {
               pinned: true,
               expandedHeight: 110,
               actions: [
+                _authController.user.value == null
+                    ? _authController.isLoading.value
+                        ? Center(child: CircularProgressIndicator())
+                        : InkWell(
+                            onTap: () {
+                              _authController.login();
+                            },
+                            child: Container(
+                              padding: EdgeInsets.all(5.0),
+                              decoration: BoxDecoration(
+                                border: Border.all(width: 1.0),
+                                borderRadius: BorderRadius.circular(13.0),
+                              ),
+                              child: Text('Sign In'),
+                            ),
+                          )
+                    : Row(
+                        children: [
+                          Text(
+                              '${_authController.user.value?.name}님 ${_authController.user.value?.pointRemained}P'),
+                          SizedBox(
+                            width: 8.0,
+                          ),
+                          InkWell(
+                            onTap: () {
+                              _authController.logout();
+                            },
+                            child: Container(
+                              padding: EdgeInsets.all(5.0),
+                              decoration: BoxDecoration(
+                                border: Border.all(width: 1.0),
+                                borderRadius: BorderRadius.circular(13.0),
+                              ),
+                              child: Text('Sign Out'),
+                            ),
+                          ),
+                        ],
+                      ),
                 GestureDetector(
                   onTap: () {
                     _rootController

--- a/lib/app/wine/pages/wine_purchase_page.dart
+++ b/lib/app/wine/pages/wine_purchase_page.dart
@@ -1,0 +1,165 @@
+import 'package:epicone_review/app/auth/controllers/auth_controller.dart';
+import 'package:epicone_review/app/wine/controllers/wine_purchase_controller.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+
+class WinePurchasePage extends StatelessWidget {
+  WinePurchasePage({
+    super.key,
+  });
+
+  final WinePurchaseController _winePurchaseController =
+      WinePurchaseController.to;
+  final AuthController _authController = AuthController.to;
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(
+      () => GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text(
+              'Wine Purchase',
+            ),
+          ),
+          body: SingleChildScrollView(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 13.0, vertical: 18.0),
+              child: Column(
+                children: [
+                  Center(
+                    child: Image.network(_winePurchaseController.wine.image),
+                  ),
+                  SizedBox(height: 20),
+                  Text(
+                    _winePurchaseController.wine.winery,
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.displayLarge,
+                  ),
+                  SizedBox(height: 20),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Text(
+                      '구매자: ${_authController.user.value?.name}',
+                      textAlign: TextAlign.left,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Text(
+                      '가격: ${_winePurchaseController.wine.price}원',
+                      textAlign: TextAlign.left,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ),
+                  SizedBox(height: 20),
+                  CupertinoTextField(
+                    focusNode: _winePurchaseController.addressFocusNode,
+                    controller: _winePurchaseController.addressController,
+                    keyboardType: TextInputType.text,
+                    placeholder: '배송 주소',
+                  ),
+                  SizedBox(height: 20),
+                  CupertinoTextField(
+                    focusNode: _winePurchaseController.addressDetailFocusNode,
+                    controller: _winePurchaseController.addressDetailController,
+                    keyboardType: TextInputType.text,
+                    placeholder: '배송 주소 상세',
+                  ),
+                  SizedBox(height: 20),
+                  CupertinoTextField(
+                    focusNode: _winePurchaseController.pointsUsedFocusNode,
+                    controller: _winePurchaseController.pointsUsedController,
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    placeholder: '사용할 포인트',
+                    suffix: InkWell(
+                      onTap: () {
+                        _winePurchaseController.clickUsePointBtn();
+                      },
+                      child: Container(
+                        padding: EdgeInsets.symmetric(
+                            horizontal: 8.0, vertical: 5.0),
+                        decoration: BoxDecoration(
+                          border: Border.all(width: 1.0),
+                          borderRadius: BorderRadius.circular(13.0),
+                        ),
+                        child: Text(
+                          '사용하기',
+                          textAlign: TextAlign.left,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Text(
+                      '(최대 사용가능 포인트: ${_winePurchaseController.pointCanUseLimit}P)',
+                      textAlign: TextAlign.right,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Text(
+                      '보유 포인트: ${_authController.user.value?.pointRemained}P',
+                      textAlign: TextAlign.right,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                  SizedBox(height: 20),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Text(
+                      '사용 포인트: ${_winePurchaseController.confirmPointsUsed}P',
+                      textAlign: TextAlign.left,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ),
+                  SizedBox(height: 5),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Text(
+                      '결제 예정 금액: ${_winePurchaseController.confirmPrice}원',
+                      textAlign: TextAlign.left,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ),
+                  SizedBox(height: 20),
+                  _winePurchaseController.isLoadingPurchase.value
+                      ? Center(
+                          child: CircularProgressIndicator(),
+                        )
+                      : InkWell(
+                          onTap: () {
+                            _winePurchaseController.postPurchase();
+                          },
+                          child: Container(
+                            padding: EdgeInsets.all(12.0),
+                            decoration: BoxDecoration(
+                              border: Border.all(width: 1.0),
+                              borderRadius: BorderRadius.circular(13.0),
+                            ),
+                            child: Text(
+                              'Purchase',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodyLarge,
+                            ),
+                          ),
+                        ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:epicone_review/app/auth/bindings/auth_binding.dart';
 import 'package:epicone_review/router/app_pages.dart';
 import 'package:epicone_review/theme.dart';
 import 'package:flutter/material.dart';
@@ -7,9 +8,11 @@ import 'app/root/bindings/root_binding.dart';
 import 'app/root/controllers/root_controller.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   runApp(const MyApp());
 
   RootBinding().dependencies();
+  AuthBinding().dependencies();
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/router/app_pages.dart
+++ b/lib/router/app_pages.dart
@@ -1,3 +1,7 @@
+import 'package:epicone_review/app/auth/bindings/auth_binding.dart';
+import 'package:epicone_review/app/wine/bindings/wine_purchase_binding.dart';
+import 'package:epicone_review/app/wine/models/wine.dart';
+import 'package:epicone_review/app/wine/pages/wine_purchase_page.dart';
 import 'package:get/get.dart';
 
 import '../app/root/pages/root_page.dart';
@@ -15,6 +19,7 @@ class AppPages {
       name: Routes.ROOT,
       page: () => const RootPage(),
       bindings: [
+        AuthBinding(),
         WineBinding(),
       ],
       children: [
@@ -22,6 +27,13 @@ class AppPages {
           participatesInRootNavigator: true,
           name: Routes.WINE,
           page: () => const WinePage(),
+        ),
+        GetPage(
+          name: Routes.WINE_PURCHASE,
+          page: () => WinePurchasePage(),
+          arguments: Wine(),
+          transition: Transition.rightToLeft,
+          binding: WinePurchaseBinding(),
         ),
       ],
     ),

--- a/lib/router/app_routes.dart
+++ b/lib/router/app_routes.dart
@@ -6,4 +6,5 @@ abstract class Routes {
   static const ROOT = '/';
   static const WINE = '/wine';
   static const WINE_DETAIL = '/wine/:id';
+  static const WINE_PURCHASE = '/wine/purchase';
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -252,10 +252,10 @@ packages:
     dependency: "direct main"
     description:
       name: get
-      sha256: "2ba20a47c8f1f233bed775ba2dd0d3ac97b4cf32fc17731b3dfc672b06b0e92a"
+      sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.5"
+    version: "4.6.6"
   glob:
     dependency: transitive
     description:
@@ -300,10 +300,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -340,26 +340,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -537,10 +537,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   timing:
     dependency: transitive
     description:
@@ -569,10 +569,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -598,4 +598,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 
   get: ^4.6.5
   http: ^1.0.0
-  intl: ^0.18.0
+  intl: ^0.19.0
   cupertino_icons: ^1.0.2
   json_serializable: ^6.7.0
   freezed_annotation: ^2.2.0


### PR DESCRIPTION
# flutter 버전 호환성을 위해 pubspec을 수정 했습니다.
# 로그인은 기존 구조의 repository를  api, repository로 분리하여 구현 해보았고, 와인 구매는 기존 wine 폴더 구조에 맞추어 구현 해보았습니다.

# 아래는 구현 사항에 대한 요약 정리입니다.

# 로그인 기능 구현
    * auth 폴더 추가
    * api -> repository -> controller -> view 패턴으로 구성(로그인 버튼이 와인 목록 페이지에 들어가서 view는 생략)
    * 인증/유저정보는 전역으로 사용되기 때문에 rootBindings와 같이 main에서 의존성 주입
    * 로그인 실패 확률을 반영하여 자동 재요청을 하도록 구현 했으며 정해진 횟수 이상 실패할 경우 다이얼로그 출력
    * 로그인 성공시 이름, 보유 포인트, 로그아웃 버튼 출력

# 와인 구매 기능 구현
    * 기존 wine 폴더 내에 추가 구현
    * 기존 폴더 구조에 맞게 코드 추가
    * 와인 상세보기페이지에 구매하기 버튼 추가, 로그인 상태에서만 구매페이지로 넘어갈 수 있고 비로그인시 다이얼로그 출력
    * 주소, 상세주소, 사용할 포인트를 사용자에게 입력 받고 미입력시 구매 버튼에서 다이얼로그 출력
    * 사용할 포인트 입력 후 사용하기 버튼 클릭시 사용 포인트 적용(숫자만 입력 가능, 보유 포인트 또는 최대 사용가능 포인트를 초과할시 이에 대한 다이얼로그 출력)
    * FocusNode를 사용하여 TextField 밖의 화면을 터치하면 focus가 해제되도록 하여 사용성 개선
    * api 연동은 로그인과 동일하게 재요청 구현